### PR TITLE
Change all instances of "an SRFI" to "a SRFI".

### DIFF
--- a/srfi-faq.html
+++ b/srfi-faq.html
@@ -69,7 +69,7 @@ cluttering up that document.
 
       <p>Of course anyone, including authors of future Revised
       Reports, is welcome to employ the definition and rationale of
-      an SRFI, the discussion surrounding its adoption, and its
+      a SRFI, the discussion surrounding its adoption, and its
       widespread implementation to argue that the authors of a
       standard or report should consider adding the contents of the
       SRFI to that standard.
@@ -242,7 +242,7 @@ cluttering up that document.
     proposed.
 
     <dt>Are there any special considerations if I use Github to
-    propose or comment on an SRFI?
+    propose or comment on a SRFI?
 
     <dd>Please keep the discussion of each SRFI on its mailing
     list. For example, if you create a pull request, send all your
@@ -258,7 +258,7 @@ cluttering up that document.
     revisions to them, feel free to point the editors at alternate
     Git repos or to send us patch files. (Patch files can be
     created using <code>git format-patch -M origin/master</code> or
-    <code>git send-email</code>.) If you're an SRFI author and
+    <code>git send-email</code>.) If you're a SRFI author and
     would rather not use Git, either, just send updated files (or
     links to them) and we'll check in the changes.
   </dl>

--- a/srfi-list-subscribe.html
+++ b/srfi-list-subscribe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 3.2//EN">
 <html>
   <head>
-    <title>Subscribing to an SRFI Mailing List</title>
+    <title>Subscribing to a SRFI Mailing List</title>
     <link href="/admin.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
 


### PR DESCRIPTION
As mentioned in the SRFI FAQ, the recommended pronunciation for SRFI is "surfie". Therefore, it should be "a SRFI", not "an SRFI". In the SRFI FAQ, there are currently 4 instances of "a SRFI" and 3 instances of "an SRFI", which is not consistent. This pull request standardises on "a SRFI" across the board.
