### PR TITLE
Updated URL for R7RS SRFI implementations from gitorious to github.

### DIFF
--- a/srfi-implementers.html
+++ b/srfi-implementers.html
@@ -94,7 +94,7 @@ The following systems are claimed to support one or more SRFIs:
 <h1>R7RS-small implementations of SRFIs</h1>
 
 There is a project for making R7RS-small implementations of SRFIs <a
-href="https://gitorious.org/taylan-scheme/srfi/">here</a>.
+href="https://github.com/TaylanUB/scheme-srfis">here</a>.
 
 <h1>Availability SRFIs</h1>
 Note that unless an implementation provides one of the availability


### PR DESCRIPTION
The current/old link to gitorious.org leads to a placeholder page. I believe the github.com link I put in is the correct master version now, although I also found another one hosted at notabug.org.

Regards,

-chaw