### PR TITLE
Add see-also pointer from 132 to 32

### DIFF
--- a/admin/srfi-data.scm
+++ b/admin/srfi-data.scm
@@ -1147,7 +1147,7 @@
  (author "John Cowan")
  (based-on "Based on SRFI 32 by Olin Shivers.")
  (library-name sorting)
- (see-also)
+ (see-also 32)
  (keywords "algorithm")
  (draft-date "2015-12-09")
  (done-date "2016-04-20"))


### PR DESCRIPTION
Even though 32 is withdrawn, the see-also entry should probably still be there since 132 is based on 32.