### PR TITLE
Coin library-name for withdrawn SRFI 15

### DIFF
--- a/admin/srfi-data.scm
+++ b/admin/srfi-data.scm
@@ -136,6 +136,7 @@
  (status withdrawn)
  (title "Syntax for dynamic scoping")
  (author "Lars T Hansen")
+ (library-name fluid-let)
  (see-also)
  (keywords binding)
  (draft-date "1999-11-06")


### PR DESCRIPTION
SRFI 97 didn't coin names for withdrawn SRFIs. Can we coin names for them now?

Ref: https://github.com/arcfide/chez-srfi/issues/71