### PR TITLE
Fix abstract-html command

### DIFF
--- a/srfi-tools/html.sld
+++ b/srfi-tools/html.sld
@@ -54,8 +54,7 @@
       (file-contents-as-string (srfi-abstract-html-file num)))
 
     (define-command (abstract-html num)
-      (sxml-display-as-html
-       (srfi-abstract-sxml (parse-srfi-number num))))
+      (write-string (srfi-abstract-html (parse-srfi-number num))))
 
     (define (srfi-abstract-text num)
       (render-web-page-as-plain-text (srfi-abstract-html-file num)))

--- a/srfi-tools/private/sysdep.gauche.scm
+++ b/srfi-tools/private/sysdep.gauche.scm
@@ -8,7 +8,8 @@
                       make-keyword)
                 gauche:)
         (prefix (gauche process)
-                gauche:))
+                gauche:)
+        (srfi-tools private port))
 
 (begin
 


### PR DESCRIPTION
Avoid spurious <*TOP*> in output. (It was caused by SXML parsing.)