### PR TITLE
Add send-mail command

### DIFF
--- a/srfi-tools/interactive.sld
+++ b/srfi-tools/interactive.sld
@@ -9,7 +9,8 @@
           srfi-browse-github-url
           srfi-pager
           srfi-edit
-          srfi-browse-mail-archive-url)
+          srfi-browse-mail-archive-url
+          srfi-send-mail)
   (import (scheme base)
           (srfi-tools private external)
           (srfi-tools private os)
@@ -115,4 +116,11 @@
 
     (define-command (browse-mail-archive-url num)
       "Browse the email archive for SRFI <num>."
-      (srfi-browse-mail-archive-url (parse-srfi-number num)))))
+      (srfi-browse-mail-archive-url (parse-srfi-number num)))
+
+    (define (srfi-send-mail num)
+      (desktop-open (srfi-mailto-url num)))
+
+    (define-command (send-mail num)
+      "Open email app with a new email to SRFI <num> mailing list."
+      (srfi-send-mail (parse-srfi-number num)))))

--- a/srfi-tools/mail.sld
+++ b/srfi-tools/mail.sld
@@ -1,9 +1,11 @@
 (define-library (srfi-tools mail)
   (export srfi-mail-archive-url
-          srfi-mail-address)
+          srfi-mail-address
+          srfi-mailto-url)
   (import (scheme base)
           (srfi-tools private path)
           (srfi-tools private port)
+          (srfi-tools private string)
           (srfi-tools private command)
           (srfi-tools data)
           (srfi-tools path))
@@ -23,4 +25,9 @@
 
     (define-command (mail-address num)
       "Display email address URL for SRFI <num>."
-      (write-line-about-srfi srfi-mail-address num))))
+      (write-line-about-srfi srfi-mail-address num))
+
+    (define (srfi-mailto-url num)
+      (string-append "mailto:"
+                     (srfi-mail-address num)
+                     "?subject=" (url-hexify-string (srfi-title num))))))


### PR DESCRIPTION
The title of the SRFI is given as the initial subject of the message to reduce the chances of accidentally sending mail to the wrong list.