### PR TITLE
Fix duplicate with-output-to-string

### DIFF
--- a/srfi-tools/private/port.sld
+++ b/srfi-tools/private/port.sld
@@ -1,7 +1,6 @@
 (define-library (srfi-tools private port)
   (export read-all
           read-all-chars
-          with-output-to-string
           write-bytevector-as-hex
           write-line
           written
@@ -31,13 +30,6 @@
               whole
               (loop (string-append whole part)
                     (* attempt 2))))))
-
-    (define (with-output-to-string thunk)
-      (call-with-port (open-output-string)
-        (lambda (port)
-          (parameterize ((current-output-port port))
-            (thunk))
-          (get-output-string port))))
 
     (define (write-bytevector-as-hex bytes)
       (do ((i 0 (+ 1 i)))

--- a/srfi-tools/private/string.sld
+++ b/srfi-tools/private/string.sld
@@ -44,7 +44,8 @@
    string-join-english
    string->slug
    unique-string-accumulator
-   url-hexify-string)
+   url-hexify-string
+   with-output-to-string)
   (import (scheme base)
           (scheme char)
 	  (scheme write)

--- a/srfi-tools/rss.sld
+++ b/srfi-tools/rss.sld
@@ -9,6 +9,7 @@
           (srfi-tools private format)
           (srfi-tools private time)
           (srfi-tools private port)
+          (srfi-tools private string)
           (srfi-tools private sxml)
           (srfi-tools private html-parser)
           (srfi-tools private html-writer)


### PR DESCRIPTION
This helper procedure was defined identically in two libraries. Remove the definition from (srfi-tools private port) and export the one in (srfi-tools private string).