### PR TITLE
Add borders to tables for clarity

### DIFF
--- a/srfi.css
+++ b/srfi.css
@@ -37,6 +37,15 @@ span.antispam {
 pre {
   white-space: pre-wrap;
 }
+table {
+  border-collapse: collapse;
+  border-width: 0.1em;
+  border-style: solid;
+}
+td {
+  border-width: 0.1em;
+  border-style: solid;
+}
 .todo {
   color: red;
   font-family: monospace;


### PR DESCRIPTION
This is because default HTML tables are hard to read due to unclear/absent cell borders. See https://srfi.schemers.org/srfi-48/srfi-48.html#format `~h` and the surrounding cells for an example of such a confusion.

An alternative would be to increase spacing between cells, but this is both eating up screen real estate (especially for me with my x2 scaling), and perpetuating the border clarity problem.